### PR TITLE
Feat/issue #15

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/annotation/TokenMemberResolver.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/annotation/TokenMemberResolver.java
@@ -1,6 +1,5 @@
 package com.gdsc_knu.official_homepage.annotation;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gdsc_knu.official_homepage.authentication.JwtTokenValidator;
 import com.gdsc_knu.official_homepage.authentication.redis.JwtMemberDetail;
 import com.gdsc_knu.official_homepage.entity.Member;
@@ -8,9 +7,6 @@ import com.gdsc_knu.official_homepage.exception.CustomException;
 import com.gdsc_knu.official_homepage.exception.ErrorCode;
 import com.gdsc_knu.official_homepage.repository.MemberRepository;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
-import io.micrometer.common.util.StringUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.MethodParameter;

--- a/src/main/java/com/gdsc_knu/official_homepage/annotation/TokenMemberResolver.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/annotation/TokenMemberResolver.java
@@ -3,6 +3,10 @@ package com.gdsc_knu.official_homepage.annotation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.gdsc_knu.official_homepage.authentication.JwtTokenValidator;
 import com.gdsc_knu.official_homepage.authentication.redis.JwtMemberDetail;
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.exception.CustomException;
+import com.gdsc_knu.official_homepage.exception.ErrorCode;
+import com.gdsc_knu.official_homepage.repository.MemberRepository;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
@@ -21,6 +25,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Component
 public class TokenMemberResolver implements HandlerMethodArgumentResolver {
     private final JwtTokenValidator jwtTokenValidator;
+    private final MemberRepository memberRepository;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -37,9 +42,12 @@ public class TokenMemberResolver implements HandlerMethodArgumentResolver {
         Claims claims = jwtTokenValidator.extractClaims(jwtToken);
 
         String email = claims.getSubject();
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 
         return JwtMemberDetail.builder()
                 .email(email)
+                .member(member)
                 .build();
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/authentication/JwtFilter.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/authentication/JwtFilter.java
@@ -30,6 +30,12 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String jwtHeader = request.getHeader("Authorization");
 
+        // 인증이 필요없는 요청은 바로 리턴(이 필터에 안걸려도 인증은 리졸버를 통해 수행함)
+        if (jwtHeader==null){
+            chain.doFilter(request,response);
+            return;
+        }
+
         String jwtToken = jwtTokenValidator.checkAccessToken(jwtHeader);
         Claims claims = jwtTokenValidator.extractClaims(jwtToken);
         String email = claims.getSubject();

--- a/src/main/java/com/gdsc_knu/official_homepage/authentication/JwtFilter.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/authentication/JwtFilter.java
@@ -1,0 +1,51 @@
+package com.gdsc_knu.official_homepage.authentication;
+
+import com.gdsc_knu.official_homepage.authentication.redis.JwtMemberDetail;
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.exception.CustomException;
+import com.gdsc_knu.official_homepage.exception.ErrorCode;
+import com.gdsc_knu.official_homepage.repository.MemberRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AllArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+// 인증이 필요한 모든 요청은 JwtFilter를 탐.
+@AllArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+    private JwtTokenValidator jwtTokenValidator;
+    private MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        String jwtHeader = request.getHeader("Authorization");
+
+        String jwtToken = jwtTokenValidator.checkAccessToken(jwtHeader);
+        Claims claims = jwtTokenValidator.extractClaims(jwtToken);
+        String email = claims.getSubject();
+
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+        JwtMemberDetail jwtMemberDetail = new JwtMemberDetail(member,member.getEmail());
+
+        // jwt 서명이 정상이면 Authentication객체를 만듦.
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(jwtMemberDetail, null, jwtMemberDetail.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        chain.doFilter(request,response);
+
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/authentication/redis/JwtMemberDetail.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/authentication/redis/JwtMemberDetail.java
@@ -7,14 +7,14 @@ import lombok.Builder;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-
+import io.swagger.v3.oas.annotations.Hidden;
 import java.util.ArrayList;
 import java.util.Collection;
 
 @Getter
 @AllArgsConstructor
 @Builder
-@Nullable
+@Hidden
 public class JwtMemberDetail implements UserDetails {
     private Member member;
     private String email;

--- a/src/main/java/com/gdsc_knu/official_homepage/authentication/redis/JwtMemberDetail.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/authentication/redis/JwtMemberDetail.java
@@ -1,12 +1,59 @@
 package com.gdsc_knu.official_homepage.authentication.redis;
 
+import com.gdsc_knu.official_homepage.entity.Member;
+import jakarta.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 @Getter
 @AllArgsConstructor
 @Builder
-public class JwtMemberDetail {
+@Nullable
+public class JwtMemberDetail implements UserDetails {
+    private Member member;
     private String email;
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add((GrantedAuthority) () -> String.valueOf(member.getRole()));
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getName();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
@@ -23,7 +23,7 @@ public class SecurityConfig {
     private final MemberRepository memberRepository;
 
     private static final String[] WHITE_LIST = {
-            "/**"
+            "/**",
     };
     private static final String[] MEMBER_AUTHENTICATION_LIST = {
             "/api/jwt/member"

--- a/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
@@ -6,18 +6,12 @@ import com.gdsc_knu.official_homepage.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.Customizer;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
-import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
-import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 @Configuration

--- a/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/config/SecurityConfig.java
@@ -1,14 +1,20 @@
 package com.gdsc_knu.official_homepage.config;
 
+import com.gdsc_knu.official_homepage.authentication.JwtFilter;
+import com.gdsc_knu.official_homepage.authentication.JwtTokenValidator;
+import com.gdsc_knu.official_homepage.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
 import org.springframework.security.web.util.matcher.MediaTypeRequestMatcher;
 import org.springframework.web.servlet.HandlerMapping;
@@ -19,22 +25,28 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 @EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtTokenValidator jwtTokenValidator;
+    private final MemberRepository memberRepository;
+
     private static final String[] WHITE_LIST = {
             "/**"
     };
     private static final String[] MEMBER_AUTHENTICATION_LIST = {
-
+            "/api/jwt/member"
     };
 
     private static final String[] CORE_AUTHENTICATION_LIST = {
-
+            "/api/jwt/core"
     };
+
     @Bean
     protected SecurityFilterChain filterChain(HttpSecurity httpSecurity, HandlerMappingIntrospector introspector) throws Exception {
         httpSecurity
                 .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new JwtFilter(jwtTokenValidator,memberRepository), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(authorizeRequest -> authorizeRequest
-                        .requestMatchers(WHITE_LIST).permitAll()
                         .requestMatchers(MEMBER_AUTHENTICATION_LIST).hasRole("MEMBER")
                         .requestMatchers(CORE_AUTHENTICATION_LIST).hasRole("CORE")
                         .anyRequest().permitAll()

--- a/src/main/java/com/gdsc_knu/official_homepage/config/SwaggerConfig.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.gdsc_knu.official_homepage.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -10,9 +12,19 @@ import org.springframework.context.annotation.Configuration;
 public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
+        String jwt = "accessToken";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwt);
+        Components components = new Components().addSecuritySchemes(jwt, new SecurityScheme()
+                .name(jwt)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+        );
         return new OpenAPI()
                 .components(new Components())
-                .info(apiInfo());
+                .info(apiInfo())
+                .addSecurityItem(securityRequirement)
+                .components(components);
     }
     private Info apiInfo() {
         return new Info()

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/AuthController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.gdsc_knu.official_homepage.controller;
 import com.gdsc_knu.official_homepage.dto.oauth.GoogleCode;
 import com.gdsc_knu.official_homepage.dto.oauth.LoginResponseDto;
 import com.gdsc_knu.official_homepage.oauth.OAuthService;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,13 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class AuthController {
     private final OAuthService oAuthService;
+
+    // 로컬환경에서 테스트를 위함
+    @Hidden
+    @GetMapping("google/oauth")
+    public ResponseEntity<LoginResponseDto> googleOAuth(@RequestParam(name="code")String code){
+        return ResponseEntity.ok().body(oAuthService.getGoogleAccessToken(code));
+    }
 
     @PostMapping("google/oauth")
     public ResponseEntity<LoginResponseDto> googleOAuth(@RequestBody GoogleCode code){

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/JwtTestController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/JwtTestController.java
@@ -5,10 +5,12 @@ import com.gdsc_knu.official_homepage.authentication.JwtTokenProvider;
 import com.gdsc_knu.official_homepage.authentication.JwtTokenValidator;
 import com.gdsc_knu.official_homepage.authentication.redis.JwtMemberDetail;
 import com.gdsc_knu.official_homepage.dto.jwt.TokenResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Hidden
 @RequestMapping("/api/jwt")
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/JwtTestController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/JwtTestController.java
@@ -34,4 +34,16 @@ public class JwtTestController {
     public ResponseEntity<TokenResponse> reissueTokens(@RequestHeader("Authorization") String token) {
         return ResponseEntity.ok().body(jwtTokenProvider.reissueTokens(token));
     }
+
+    // 권한 부여를 확인하기 위한 컨트롤러입니다.
+    @GetMapping("/member")
+    public String member(){
+        return "member 권한을 가집니다.";
+    }
+    @GetMapping("/core")
+    public String core(){
+        return "core 권한을 가집니다.";
+    }
+
+
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/MemberController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/MemberController.java
@@ -28,7 +28,7 @@ public class MemberController {
         return ResponseEntity.ok().body(memberInfoService.retrieveMemberInfo(id));
     }
 
-    @PostMapping()
+    @PutMapping()
     @Operation(summary="사용자 정보 수정 API")
     public void updateMemberInfo(@RequestBody MemberInfoUpdate memberInfoUpdate,
                                  @RequestParam(name = "userId")Long id){

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/MemberController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.gdsc_knu.official_homepage.controller;
 
+import com.gdsc_knu.official_homepage.annotation.TokenMember;
+import com.gdsc_knu.official_homepage.authentication.redis.JwtMemberDetail;
 import com.gdsc_knu.official_homepage.dto.member.MemberInfoAdd;
 import com.gdsc_knu.official_homepage.dto.member.MemberInfoUpdate;
 import com.gdsc_knu.official_homepage.dto.member.MemberInfoResponse;
@@ -18,20 +20,21 @@ public class MemberController {
     private final MemberInfoService memberInfoService;
     @PostMapping("additionalInfo")
     @Operation(summary="신규가입 추가정보 입력 API")
-    public void additionalInfo(@RequestBody MemberInfoAdd request){
-        memberInfoService.addMemberInfo(request);
+    public void additionalInfo(@TokenMember JwtMemberDetail jwtMemberDetail,
+                               @RequestBody MemberInfoAdd request){
+        memberInfoService.addMemberInfo(jwtMemberDetail.getMember().getId(),request);
     }
 
     @GetMapping()
     @Operation(summary="사용자 정보 조회 API")
-    public ResponseEntity<MemberInfoResponse> retrieveMemberInfo(@RequestParam(name = "userId")Long id){
-        return ResponseEntity.ok().body(memberInfoService.retrieveMemberInfo(id));
+    public ResponseEntity<MemberInfoResponse> retrieveMemberInfo(@TokenMember JwtMemberDetail jwtMemberDetail){
+        return ResponseEntity.ok().body(memberInfoService.retrieveMemberInfo(jwtMemberDetail.getMember().getId()));
     }
 
     @PutMapping()
     @Operation(summary="사용자 정보 수정 API")
-    public void updateMemberInfo(@RequestBody MemberInfoUpdate memberInfoUpdate,
-                                 @RequestParam(name = "userId")Long id){
-        memberInfoService.updateMemberInfo(id, memberInfoUpdate);
+    public void updateMemberInfo(@TokenMember JwtMemberDetail jwtMemberDetail,
+                                 @RequestBody MemberInfoUpdate memberInfoUpdate){
+        memberInfoService.updateMemberInfo(jwtMemberDetail.getMember().getId(), memberInfoUpdate);
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/SignupRequest.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/SignupRequest.java
@@ -34,7 +34,7 @@ public class SignupRequest {
                 .studentNumber(studentNumber)
                 .major(major)
                 .email(email)
-                .role(Role.MEMBER)
+                .role(Role.ROLE_MEMBER)
                 .build();
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/member/MemberInfoAdd.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/member/MemberInfoAdd.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 
 @Getter
 public class MemberInfoAdd {
-    private Long id;
     private String name;
     private int age;
     private String studentNumber;

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/oauth/GoogleUserInfo.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/oauth/GoogleUserInfo.java
@@ -22,7 +22,7 @@ public class GoogleUserInfo {
                 .email(email)
                 .profileUrl(picture)
                 .name(name)
-                .role(Role.TEMP)
+                .role(Role.ROLE_TEMP)
                 .build();
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/Member.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/Member.java
@@ -55,6 +55,6 @@ public class Member extends BaseTimeEntity{
         this.age = age;
         this.major = major;
         this.studentNumber = studentNumber;
-        this.role = Role.MEMBER;
+        this.role = Role.ROLE_MEMBER;
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/enumeration/Role.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/enumeration/Role.java
@@ -1,5 +1,5 @@
 package com.gdsc_knu.official_homepage.entity.enumeration;
 
 public enum Role {
-    GUEST, MEMBER, CORE, TEMP
+    ROLE_GUEST, ROLE_MEMBER, ROLE_CORE, ROLE_TEMP
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/oauth/OAuthService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/oauth/OAuthService.java
@@ -58,7 +58,7 @@ public class OAuthService {
 
         return new LoginResponseDto(
                 member.getId(),
-                member.getRole()==Role.TEMP,
+                member.getRole()==Role.ROLE_TEMP,
                 response.getAccessToken(),
                 response.getAccessToken());
     }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoService.java
@@ -7,5 +7,5 @@ import com.gdsc_knu.official_homepage.dto.member.MemberInfoResponse;
 public interface MemberInfoService {
     MemberInfoResponse retrieveMemberInfo(Long id);
     void updateMemberInfo(Long id, MemberInfoUpdate memberInfoUpdate);
-    void addMemberInfo(MemberInfoAdd memberInfoAdd);
+    void addMemberInfo(Long id, MemberInfoAdd memberInfoAdd);
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
@@ -54,8 +54,8 @@ public class MemberInfoServiceImpl implements MemberInfoService {
 
     @Transactional
     @Override
-    public void addMemberInfo(MemberInfoAdd memberInfo) {
-        Member member = memberRepository.findById(memberInfo.getId())
+    public void addMemberInfo(Long id, MemberInfoAdd memberInfo) {
+        Member member = memberRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
         member.addInfo(memberInfo.getName(),
                 memberInfo.getAge(),


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- JwtFilter 를 만들어 인증과 인가 작업 수행
- Role 에 따른 권한 부여
- 인증이 필요한 요청에 대해 TokenMember를 이용해 사용자 정보 가져오도록 수정
---

### ✨ 참고 사항

1. JwtMemberDetail 클래스에 UserDetails 상속하도록 수정해서 Authentication객체에서 사용자 정보로 사용하도록 구현했는데 이대로 할지 아니면 UserDetails을 상속하는 다른 클래스를 한개 더 만들지 논의 필요
2. 리졸버, 필터에서 2번 인증을 진행하는 문제 (필터에서 jwtTokenValidator를 이용하지 않고 페이로드에서 이메일만 가져오도록 수정하는게 맞는 방향인지 논의 필요)
3. JwtMemberDetail 클래스가 redis 폴더에 위치 /  authentication 폴더에 JwtFilter(인가 역할도 함)클래스가 위치  -> (어디로 옮겨야  할지 모르겠네요...)

---

### ⏰ 현재 버그

---

### ✏ Git Close
closes #15 