### PR TITLE
Fix: track enum에 디자이너 추가

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/entity/enumeration/Track.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/enumeration/Track.java
@@ -1,5 +1,5 @@
 package com.gdsc_knu.official_homepage.entity.enumeration;
 
 public enum Track {
-    FRONT_END, BACK_END, ANDROID, AI
+    FRONT_END, BACK_END, ANDROID, AI, DESIGNER
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
트랙에 누락된 디자이너 추가

---

### ✨ 참고 사항
4기부터는 디자이너도 GDSC 모집 시에 동시 선발 예정

---

### ⏰ 현재 버그

---

### ✏ Git Close