### PR TITLE
Fix: 자기소개 필드 길이 500자로 변경

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/entity/Member.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/Member.java
@@ -38,6 +38,7 @@ public class Member extends BaseTimeEntity{
 
     private String profileUrl;
 
+    @Column(length = 500)
     private String introduction;
 
     private Track track;


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
기본 값(255자)으로 적용되어 있던 introduction field를 500자로 알맞게 수정

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close

closes #47 