### PR TITLE
Feat/issue #54

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminTeamController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminTeamController.java
@@ -7,6 +7,7 @@ import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamChangeRequest;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamCreateRequest;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamResponse;
 import com.gdsc_knu.official_homepage.service.admin.AdminTeamService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,26 +24,60 @@ public class AdminTeamController {
     private final AdminTeamService adminTeamService;
 
     @GetMapping()
+    @Operation(summary = "모든 팀 정보 조회 API", description = "존재하는 모든 팀의 정보를 조회 합니다.")
     public ResponseEntity<List<AdminTeamResponse>> getTeamTags() {
         return ResponseEntity.ok().body(adminTeamService.getTeamInfos());
     }
 
     @PostMapping()
+    @Operation(summary = "부모 팀 생성 API",
+            description =
+                    """
+                    부모 팀 의미: 'Study-BE', 'Study-FE', '1차 프로젝트' 등의 주제별로 나눠진 대분류 팀.
+                    
+                    팀 생성 시, 팀 이름(필수)과 트랙(선택)을 입력 받아 팀을 생성합니다.
+                    
+                    트랙 입력이 없으면 전체 멤버를 직렬과 상관 없이 해당 팀에 소속 시킵니다.
+                    """)
     public ResponseEntity<Long> createTeam(@RequestBody AdminTeamCreateRequest adminTeamCreateRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(adminTeamService.createTeam(adminTeamCreateRequest));
     }
 
     @PostMapping("/{teamId}/subTeam")
+    @Operation(summary = "서브 팀 생성 API",
+            description =
+                    """
+                    서브 팀 의미: 'Study-BE 1팀', 'Study-BE 2팀', ... 'Study-BE x팀' 형태로 뒤에 숫자로 나눠진 소분류 팀.
+                    
+                    부모 팀의 ID를 입력 받아 해당 팀의 하위 팀을 생성 합니다.
+                    """)
+
     public ResponseEntity<Long> createSubTeam(@PathVariable("teamId") Long parentTeamId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(adminTeamService.createSubTeam(parentTeamId));
     }
 
     @GetMapping("/{teamId}")
+    @Operation(summary = "팀원 정보 조회 API",
+            description =
+                    """
+                    팀 ID를 입력 받아 해당 팀의 팀원 정보를 조회합니다.
+                    
+                    이름, 학번, 프로필 이미지 url을 반환합니다.
+                    
+                    미배치 팀원은 부모 팀에 속해있으며, 배치된 팀원은 서브 팀에 속해있습니다.
+                    """)
     public ResponseEntity<List<AdminMemberResponse>> getTeamMembers(@PathVariable("teamId") Long teamId) {
         return ResponseEntity.ok().body(adminTeamService.getTeamMembers(teamId));
     }
 
     @PutMapping()
+    @Operation(summary = "팀원 변경 API",
+            description =
+                    """
+                    기존 팀 ID, 옮길 팀 ID, 멤버 ID를 받아 멤버의 소속 팀을 변경합니다.
+                    
+                    존재하지 않거나 동일한 팀으로 이동할 수 없습니다.
+                    """)
     public ResponseEntity<Long> changeTeamMember(@RequestBody AdminTeamChangeRequest adminTeamChangeRequest) {
         return ResponseEntity.ok().body(adminTeamService.changeTeamMember(adminTeamChangeRequest));
     }

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminTeamController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminTeamController.java
@@ -23,35 +23,27 @@ public class AdminTeamController {
     private final AdminTeamService adminTeamService;
 
     @GetMapping()
-    public ResponseEntity<List<AdminTeamResponse>> getTeamTags(@TokenMember JwtMemberDetail jwtMemberDetail) {
+    public ResponseEntity<List<AdminTeamResponse>> getTeamTags() {
         return ResponseEntity.ok().body(adminTeamService.getTeamInfos());
     }
 
     @PostMapping()
-    public ResponseEntity<Long> createTeam(
-            @TokenMember JwtMemberDetail jwtMemberDetail,
-            @RequestBody AdminTeamCreateRequest adminTeamCreateRequest) {
+    public ResponseEntity<Long> createTeam(@RequestBody AdminTeamCreateRequest adminTeamCreateRequest) {
         return ResponseEntity.status(HttpStatus.CREATED).body(adminTeamService.createTeam(adminTeamCreateRequest));
     }
 
     @PostMapping("/{teamId}/subTeam")
-    public ResponseEntity<Long> createSubTeam(
-            @TokenMember JwtMemberDetail jwtMemberDetail,
-            @PathVariable("teamId") Long parentTeamId) {
+    public ResponseEntity<Long> createSubTeam(@PathVariable("teamId") Long parentTeamId) {
         return ResponseEntity.status(HttpStatus.CREATED).body(adminTeamService.createSubTeam(parentTeamId));
     }
 
     @GetMapping("/{teamId}")
-    public ResponseEntity<List<AdminMemberResponse>> getTeamMembers(
-            @TokenMember JwtMemberDetail jwtMemberDetail,
-            @PathVariable("teamId") Long teamId) {
+    public ResponseEntity<List<AdminMemberResponse>> getTeamMembers(@PathVariable("teamId") Long teamId) {
         return ResponseEntity.ok().body(adminTeamService.getTeamMembers(teamId));
     }
 
     @PutMapping()
-    public ResponseEntity<Long> changeTeamMember(
-            @TokenMember JwtMemberDetail jwtMemberDetail,
-            @RequestBody AdminTeamChangeRequest adminTeamChangeRequest) {
+    public ResponseEntity<Long> changeTeamMember(@RequestBody AdminTeamChangeRequest adminTeamChangeRequest) {
         return ResponseEntity.ok().body(adminTeamService.changeTeamMember(adminTeamChangeRequest));
     }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminTeamController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminTeamController.java
@@ -1,0 +1,57 @@
+package com.gdsc_knu.official_homepage.controller.admin;
+
+import com.gdsc_knu.official_homepage.annotation.TokenMember;
+import com.gdsc_knu.official_homepage.authentication.jwt.JwtMemberDetail;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamChangeRequest;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamCreateRequest;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamInfoResponse;
+import com.gdsc_knu.official_homepage.service.admin.AdminTeamService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Admin Team", description = "관리자 팀 관리용 API")
+@RestController
+@RequestMapping("/api/admin/team")
+@RequiredArgsConstructor
+public class AdminTeamController {
+    private final AdminTeamService adminTeamService;
+
+    @GetMapping()
+    public ResponseEntity<List<AdminTeamInfoResponse>> getTeamTags(@TokenMember JwtMemberDetail jwtMemberDetail) {
+        return ResponseEntity.ok().body(adminTeamService.getTeamInfos());
+    }
+
+    @PostMapping()
+    public ResponseEntity<Long> createTeam(
+            @TokenMember JwtMemberDetail jwtMemberDetail,
+            @RequestBody AdminTeamCreateRequest adminTeamCreateRequest) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(adminTeamService.createTeam(adminTeamCreateRequest));
+    }
+
+    @PostMapping("/{teamId}/subTeam")
+    public ResponseEntity<Long> createSubTeam(
+            @TokenMember JwtMemberDetail jwtMemberDetail,
+            @PathVariable("teamId") Long parentTeamId) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(adminTeamService.createSubTeam(parentTeamId));
+    }
+
+    @GetMapping("/{teamId}")
+    public ResponseEntity<List<AdminMemberResponse>> getTeamMembers(
+            @TokenMember JwtMemberDetail jwtMemberDetail,
+            @PathVariable("teamId") Long teamId) {
+        return ResponseEntity.ok().body(adminTeamService.getTeamMembers(teamId));
+    }
+
+    @PutMapping()
+    public ResponseEntity<Long> changeTeamMember(
+            @TokenMember JwtMemberDetail jwtMemberDetail,
+            @RequestBody AdminTeamChangeRequest adminTeamChangeRequest) {
+        return ResponseEntity.ok().body(adminTeamService.changeTeamMember(adminTeamChangeRequest));
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminTeamController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminTeamController.java
@@ -5,7 +5,7 @@ import com.gdsc_knu.official_homepage.authentication.jwt.JwtMemberDetail;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamChangeRequest;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamCreateRequest;
-import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamInfoResponse;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamResponse;
 import com.gdsc_knu.official_homepage.service.admin.AdminTeamService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +23,7 @@ public class AdminTeamController {
     private final AdminTeamService adminTeamService;
 
     @GetMapping()
-    public ResponseEntity<List<AdminTeamInfoResponse>> getTeamTags(@TokenMember JwtMemberDetail jwtMemberDetail) {
+    public ResponseEntity<List<AdminTeamResponse>> getTeamTags(@TokenMember JwtMemberDetail jwtMemberDetail) {
         return ResponseEntity.ok().body(adminTeamService.getTeamInfos());
     }
 

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminMemberResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminMemberResponse.java
@@ -1,0 +1,16 @@
+package com.gdsc_knu.official_homepage.dto.admin.team;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminMemberResponse {
+    private Long id;
+    private String name;
+    private String studentNumber;
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminMemberResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminMemberResponse.java
@@ -13,4 +13,5 @@ public class AdminMemberResponse {
     private Long id;
     private String name;
     private String studentNumber;
+    private String profileUrl;
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamChangeRequest.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamChangeRequest.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class AdminTeamChangeRequest {
-    private Long teamId;
+    private Long oldTeamId;
+    private Long newTeamId;
     private Long memberId;
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamChangeRequest.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamChangeRequest.java
@@ -1,0 +1,15 @@
+package com.gdsc_knu.official_homepage.dto.admin.team;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminTeamChangeRequest {
+    private Long teamId;
+    private Long memberId;
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamCreateRequest.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamCreateRequest.java
@@ -1,0 +1,16 @@
+package com.gdsc_knu.official_homepage.dto.admin.team;
+
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminTeamCreateRequest {
+    private String teamName;
+    private Track track;
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamInfoResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamInfoResponse.java
@@ -1,0 +1,16 @@
+package com.gdsc_knu.official_homepage.dto.admin.team;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AdminTeamInfoResponse {
+    private Long id;
+    private String teamName;
+    private String teamPageUrl;
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/team/AdminTeamResponse.java
@@ -1,16 +1,22 @@
 package com.gdsc_knu.official_homepage.dto.admin.team;
 
+import com.gdsc_knu.official_homepage.dto.member.TeamInfoResponse;
+import com.gdsc_knu.official_homepage.entity.Team;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class AdminTeamInfoResponse {
+public class AdminTeamResponse {
     private Long id;
     private String teamName;
     private String teamPageUrl;
+    private List<TeamInfoResponse> subTeams = new ArrayList<>();
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/member/TeamInfoResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/member/TeamInfoResponse.java
@@ -1,11 +1,23 @@
 package com.gdsc_knu.official_homepage.dto.member;
 
+import com.gdsc_knu.official_homepage.entity.Team;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class TeamInfoResponse {
+    private Long id;
     private String teamName;
     private String teamPageUrl;
+
+    public TeamInfoResponse(Team team) {
+        this.id = team.getId();
+        this.teamName = team.getTeamName();
+        this.teamPageUrl = team.getTeamPageUrl();
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/MemberTeam.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/MemberTeam.java
@@ -1,12 +1,15 @@
 package com.gdsc_knu.official_homepage.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class MemberTeam {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/MemberTeam.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/MemberTeam.java
@@ -21,4 +21,7 @@ public class MemberTeam {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Team team;
 
+    public void changeTeam(Team team) {
+        this.team = team;
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/Team.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/Team.java
@@ -19,6 +19,7 @@ public class Team {
     private String teamPageUrl;
 
     @OneToMany(mappedBy = "team")
+    @Builder.Default
     private List<MemberTeam> memberTeams = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/Team.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/Team.java
@@ -1,7 +1,7 @@
 package com.gdsc_knu.official_homepage.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,8 +12,9 @@ public class Team {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String TeamName;
-    private String TeamPageUrl;
+    private String teamName;
+    private String teamPageUrl;
+
     @OneToMany(mappedBy = "team")
     private List<MemberTeam> memberTeams = new ArrayList<>();
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/entity/Team.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/entity/Team.java
@@ -8,6 +8,9 @@ import java.util.List;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Team {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -17,4 +20,20 @@ public class Team {
 
     @OneToMany(mappedBy = "team")
     private List<MemberTeam> memberTeams = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Team parent;
+
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
+    private List<Team> subTeams = new ArrayList<>();
+
+    public void addSubTeam(Team subteam) {
+        subTeams.add(subteam);
+        subteam.setParent(this);
+    }
+
+    public void setParent(Team parent) {
+        this.parent = parent;
+    }
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/MemberRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/MemberRepository.java
@@ -1,8 +1,10 @@
 package com.gdsc_knu.official_homepage.repository;
 
 import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -13,4 +15,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByName(String name);
 
+    List<Member> findAllByTrack(Track track);
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/MemberTeamRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/MemberTeamRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
     Optional<MemberTeam> findByMemberIdAndTeamId(Long memberId, Long teamId);
 
-    @Query("SELECT new com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse(m.id, m.name, m.email) " +
+    @Query("SELECT new com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse(m.id, m.name, m.email, m.profileUrl) " +
             "FROM MemberTeam mt " +
             "JOIN mt.member m " +
             "WHERE mt.team.id = :teamId")

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/MemberTeamRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/MemberTeamRepository.java
@@ -1,12 +1,22 @@
 package com.gdsc_knu.official_homepage.repository;
 
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse;
+import com.gdsc_knu.official_homepage.dto.member.MemberResponse;
 import com.gdsc_knu.official_homepage.entity.MemberTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
     Optional<MemberTeam> findByMemberIdAndTeamId(Long memberId, Long teamId);
 
-    Optional<MemberTeam> findAllByTeamId(Long teamId);
+    @Query("SELECT new com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse(m.id, m.name, m.email) " +
+            "FROM MemberTeam mt " +
+            "JOIN mt.member m " +
+            "WHERE mt.team.id = :teamId")
+    List<AdminMemberResponse> findAllAdminMemberResponsesByTeamId(@Param("teamId") Long teamId);
+
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/MemberTeamRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/MemberTeamRepository.java
@@ -1,0 +1,12 @@
+package com.gdsc_knu.official_homepage.repository;
+
+import com.gdsc_knu.official_homepage.entity.MemberTeam;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
+    Optional<MemberTeam> findByMemberIdAndTeamId(Long memberId, Long teamId);
+
+    Optional<MemberTeam> findAllByTeamId(Long teamId);
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
@@ -28,7 +28,7 @@ public class MemberInfoServiceImpl implements MemberInfoService {
         List<TeamInfoResponse> teamInfos = member.getMemberTeams().stream()
                 .map(memberTeam -> {
                     Team team = memberTeam.getTeam();
-                    return new TeamInfoResponse(team.getTeamName(), team.getTeamPageUrl());
+                    return new TeamInfoResponse(team.getId(), team.getTeamName(), team.getTeamPageUrl());
                 })
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamService.java
@@ -1,0 +1,19 @@
+package com.gdsc_knu.official_homepage.service.admin;
+
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamInfoResponse;
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+
+import java.util.List;
+
+public interface AdminTeamService {
+    List<AdminTeamInfoResponse> getTeamInfos();
+
+    Long createTeam(String teamName, Track track);
+
+    Long createSubTeam(Long teamId);
+
+    List<AdminMemberResponse> getTeamMembers(Long parentTeamId);
+
+    Long changeTeamMember(Long teamId, Long memberId);
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamService.java
@@ -1,19 +1,20 @@
 package com.gdsc_knu.official_homepage.service.admin;
 
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamChangeRequest;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamInfoResponse;
-import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamCreateRequest;
 
 import java.util.List;
 
 public interface AdminTeamService {
     List<AdminTeamInfoResponse> getTeamInfos();
 
-    Long createTeam(String teamName, Track track);
+    Long createTeam(AdminTeamCreateRequest adminTeamCreateRequest);
 
-    Long createSubTeam(Long teamId);
+    Long createSubTeam(Long parentTeamId);
 
-    List<AdminMemberResponse> getTeamMembers(Long parentTeamId);
+    List<AdminMemberResponse> getTeamMembers(Long teamId);
 
-    Long changeTeamMember(Long teamId, Long memberId);
+    Long changeTeamMember(AdminTeamChangeRequest adminTeamChangeRequest);
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamService.java
@@ -2,13 +2,13 @@ package com.gdsc_knu.official_homepage.service.admin;
 
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamChangeRequest;
-import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamInfoResponse;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamResponse;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamCreateRequest;
 
 import java.util.List;
 
 public interface AdminTeamService {
-    List<AdminTeamInfoResponse> getTeamInfos();
+    List<AdminTeamResponse> getTeamInfos();
 
     Long createTeam(AdminTeamCreateRequest adminTeamCreateRequest);
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
@@ -79,7 +79,7 @@ public class AdminTeamServiceImpl implements AdminTeamService {
         Team newSubTeam = teamRepository.save(Team.builder()
                 .teamName(parentTeam.getTeamName() + " " + (parentTeam.getSubTeams().size() + 1) + "팀")
                 .teamPageUrl(createTeamPageUrl(
-                        parentTeam.getTeamName() + "_" + (parentTeam.getSubTeams().size() + 1 ) + "팀"))
+                        parentTeam.getTeamName() + "-" + (parentTeam.getSubTeams().size() + 1 ) + "팀"))
                 .build());
         parentTeam.addSubTeam(newSubTeam);
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
@@ -88,12 +88,7 @@ public class AdminTeamServiceImpl implements AdminTeamService {
     @Override
     @Transactional(readOnly = true)
     public List<AdminMemberResponse> getTeamMembers(Long teamId) {
-        return memberTeamRepository.findAllByTeamId(teamId).stream()
-                .map(memberTeam -> AdminMemberResponse.builder()
-                        .id(memberTeam.getMember().getId())
-                        .name(memberTeam.getMember().getName())
-                        .studentNumber(memberTeam.getMember().getStudentNumber()).build())
-                .toList();
+        return memberTeamRepository.findAllAdminMemberResponsesByTeamId(teamId);
     }
 
     @Override

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
@@ -55,11 +55,7 @@ public class AdminTeamServiceImpl implements AdminTeamService {
                 .subTeams(new ArrayList<>())
                 .teamPageUrl(createTeamPageUrl(teamName))
                 .build());
-        // 첫 생성 시 모든 인원 0팀으로 설정, url은 생성하지 않음
-        Team initialSubTeam = teamRepository.save(Team.builder()
-                .teamName("0팀")
-                .build());
-        newTeam.addSubTeam(initialSubTeam);
+
         List<Member> members = (track != null)
                 ? memberRepository.findAllByTrack(track)
                 : memberRepository.findAll();
@@ -79,13 +75,11 @@ public class AdminTeamServiceImpl implements AdminTeamService {
     public Long createSubTeam(Long parentTeamId) {
         Team parentTeam = teamRepository.findById(parentTeamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT, "요청한 상위 팀이 존재하지 않습니다."));
-        if (parentTeam.getSubTeams().isEmpty()) {
-            throw new CustomException(ErrorCode.INVALID_INPUT, "상위 팀의 구성이 잘못 되었습니다.");
-        }
+
         Team newSubTeam = teamRepository.save(Team.builder()
-                .teamName(parentTeam.getTeamName() + " " + parentTeam.getSubTeams().size() + "팀")
+                .teamName(parentTeam.getTeamName() + " " + (parentTeam.getSubTeams().size() + 1) + "팀")
                 .teamPageUrl(createTeamPageUrl(
-                        parentTeam.getTeamName() + "_" + parentTeam.getSubTeams().size() + "팀"))
+                        parentTeam.getTeamName() + "_" + (parentTeam.getSubTeams().size() + 1 ) + "팀"))
                 .build());
         parentTeam.addSubTeam(newSubTeam);
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
@@ -52,7 +52,6 @@ public class AdminTeamServiceImpl implements AdminTeamService {
 
         Team newTeam = teamRepository.save(Team.builder()
                 .teamName(teamName)
-                .subTeams(new ArrayList<>())
                 .teamPageUrl(createTeamPageUrl(teamName))
                 .build());
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
@@ -1,7 +1,9 @@
 package com.gdsc_knu.official_homepage.service.admin;
 
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamChangeRequest;
 import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamInfoResponse;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamCreateRequest;
 import com.gdsc_knu.official_homepage.entity.Member;
 import com.gdsc_knu.official_homepage.entity.MemberTeam;
 import com.gdsc_knu.official_homepage.entity.Team;
@@ -38,7 +40,10 @@ public class AdminTeamServiceImpl implements AdminTeamService {
 
     @Override
     @Transactional
-    public Long createTeam(String teamName, Track track) {
+    public Long createTeam(AdminTeamCreateRequest adminTeamCreateRequest) {
+        String teamName = adminTeamCreateRequest.getTeamName();
+        Track track = adminTeamCreateRequest.getTrack();
+
         Team newTeam = teamRepository.save(Team.builder()
                 .teamName(teamName)
                 .teamPageUrl(createTeamPageUrl(teamName))
@@ -93,7 +98,10 @@ public class AdminTeamServiceImpl implements AdminTeamService {
 
     @Override
     @Transactional
-    public Long changeTeamMember(Long teamId, Long memberId) {
+    public Long changeTeamMember(AdminTeamChangeRequest adminTeamChangeRequest) {
+        Long memberId = adminTeamChangeRequest.getMemberId();
+        Long teamId = adminTeamChangeRequest.getTeamId();
+
         MemberTeam memberTeam = memberTeamRepository.findByMemberIdAndTeamId(memberId, teamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT, "잘못된 팀 변경 요청입니다."));
         Team newTeam = teamRepository.findById(teamId)

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
@@ -1,0 +1,115 @@
+package com.gdsc_knu.official_homepage.service.admin;
+
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminMemberResponse;
+import com.gdsc_knu.official_homepage.dto.admin.team.AdminTeamInfoResponse;
+import com.gdsc_knu.official_homepage.entity.Member;
+import com.gdsc_knu.official_homepage.entity.MemberTeam;
+import com.gdsc_knu.official_homepage.entity.Team;
+import com.gdsc_knu.official_homepage.entity.enumeration.Track;
+import com.gdsc_knu.official_homepage.exception.CustomException;
+import com.gdsc_knu.official_homepage.exception.ErrorCode;
+import com.gdsc_knu.official_homepage.repository.MemberRepository;
+import com.gdsc_knu.official_homepage.repository.MemberTeamRepository;
+import com.gdsc_knu.official_homepage.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminTeamServiceImpl implements AdminTeamService {
+    private final TeamRepository teamRepository;
+    private final MemberTeamRepository memberTeamRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AdminTeamInfoResponse> getTeamInfos() {
+        return teamRepository.findAll().stream()
+                .map(team -> AdminTeamInfoResponse.builder()
+                        .id(team.getId())
+                        .teamName(team.getTeamName())
+                        .teamPageUrl(team.getTeamPageUrl()).build())
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public Long createTeam(String teamName, Track track) {
+        Team newTeam = teamRepository.save(Team.builder()
+                .teamName(teamName)
+                .teamPageUrl(createTeamPageUrl(teamName))
+                .build());
+        // 첫 생성 시 모든 인원 0팀으로 설정
+        Team initialSubTeam = Team.builder()
+                .teamName("0팀")
+                .build();
+        newTeam.addSubTeam(initialSubTeam);
+        List<Member> members;
+        if (track != null) { // 직렬별로 구분하는 스터디 팀이라면
+            members = memberRepository.findAllByTrack(track);
+        }
+        else {
+            members = memberRepository.findAll();
+        }
+        List<MemberTeam> memberTeams = new ArrayList<>();
+        for (Member member : members) {
+            memberTeams.add(MemberTeam.builder()
+                    .member(member)
+                    .team(newTeam)
+                    .build());
+        }
+        memberTeamRepository.saveAll(memberTeams);
+
+        return newTeam.getId();
+    }
+
+    @Override
+    @Transactional
+    public Long createSubTeam(Long parentTeamId) {
+        Team parentTeam = teamRepository.findById(parentTeamId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT, "요청한 상위 팀이 존재하지 않습니다."));
+        if (parentTeam.getSubTeams().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT, "상위 팀의 구성이 잘못 되었습니다.");
+        }
+        Team newSubTeam = Team.builder()
+                .teamName(parentTeam.getTeamName() + " " + (parentTeam.getSubTeams().size() - 1) + "팀")
+                .teamPageUrl(createTeamPageUrl(
+                        parentTeam.getTeamName() + "_" + (parentTeam.getSubTeams().size() - 1) + "팀"))
+                .build();
+        parentTeam.addSubTeam(newSubTeam);
+
+        return newSubTeam.getId();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AdminMemberResponse> getTeamMembers(Long teamId) {
+        return memberTeamRepository.findAllByTeamId(teamId).stream()
+                .map(memberTeam -> AdminMemberResponse.builder()
+                        .id(memberTeam.getMember().getId())
+                        .name(memberTeam.getMember().getName())
+                        .studentNumber(memberTeam.getMember().getStudentNumber()).build())
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public Long changeTeamMember(Long teamId, Long memberId) {
+        MemberTeam memberTeam = memberTeamRepository.findByMemberIdAndTeamId(memberId, teamId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT, "잘못된 팀 변경 요청입니다."));
+        Team newTeam = teamRepository.findById(teamId)
+                .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT, "옮길 팀이 존재하지 않습니다."));
+        memberTeam.changeTeam(newTeam);
+
+        return memberTeamRepository.save(memberTeam).getId();
+    }
+
+    // 임시 url 생성
+    private String createTeamPageUrl(String teamName) {
+        return "www.gdsc-knu.com/" + teamName;
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
@@ -101,12 +101,17 @@ public class AdminTeamServiceImpl implements AdminTeamService {
     @Override
     @Transactional
     public Long changeTeamMember(AdminTeamChangeRequest adminTeamChangeRequest) {
+        Long oldTeamId = adminTeamChangeRequest.getOldTeamId();
+        Long newTeamId = adminTeamChangeRequest.getNewTeamId();
         Long memberId = adminTeamChangeRequest.getMemberId();
-        Long teamId = adminTeamChangeRequest.getTeamId();
 
-        MemberTeam memberTeam = memberTeamRepository.findByMemberIdAndTeamId(memberId, teamId)
+        if (oldTeamId.equals(newTeamId)) {
+            throw new CustomException(ErrorCode.INVALID_INPUT, "동일한 팀으로 변경할 수 없습니다.");
+        }
+
+        MemberTeam memberTeam = memberTeamRepository.findByMemberIdAndTeamId(memberId, oldTeamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT, "잘못된 팀 변경 요청입니다."));
-        Team newTeam = teamRepository.findById(teamId)
+        Team newTeam = teamRepository.findById(newTeamId)
                 .orElseThrow(() -> new CustomException(ErrorCode.INVALID_INPUT, "옮길 팀이 존재하지 않습니다."));
         memberTeam.changeTeam(newTeam);
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
1. 모든 팀 조회 기능 구현
2. 팀별 사용자 조회 기능 구현
3. 새로운 팀(부모 팀) 생성 기능 구현
4. 서브팀(스터디 BE - 1팀, 스터디 BE - 2팀, ...) 생성 기능 구현
5. 팀원 이동 기능 구현

---

### ✨ 참고 사항
- 모든 팀 조회시 부모 팀이 리스트로 조회 되고, 서브 팀은 부모 팀의 하위 리스트로 조회 됩니다.

- 디자인에 맞게 어드민 페이지에서 멤버 조회 시 이름, 학번, 프로필 이미지 url만 반환합니다.

- 최초 생성 시에는 부모 팀에 직렬에 맞게 멤버가 소속되며, 이후 서브 팀으로 옮겨 정상적 팀 배치가 가능합니다.

---

### ⏰ 현재 버그
swagger @Operation(description="...") 작성 시 줄바꿈 두개 해야 줄바꿈이 되어 출력되는데 저만 그런걸까요...?

---

### ✏ Git Close
closes #54 