### PR TITLE
Feat/issue #84

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/authentication/jwt/JwtProvider.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/authentication/jwt/JwtProvider.java
@@ -19,7 +19,7 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Slf4j
 public class JwtProvider {
-    private final long jwtAccessExpiration = 1000 * 10; // 10초
+    private final long jwtAccessExpiration = 1000 * 60 * 60 * 24; // 1일
     private final long jwtRefreshExpiration = 1000 * 60 * 60 * 24 * 14; // 1주
 
     private final RedisRepository redisRepository;

--- a/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminApplicationController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/admin/AdminApplicationController.java
@@ -11,6 +11,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @Tag(name = "Admin Application", description = "서류확인 관련 API")
 @RestController
 @RequestMapping("/api/admin/application")
@@ -21,6 +23,12 @@ public class AdminApplicationController {
     @Operation(summary="지원서류 통계데이터 조회 API")
     public ResponseEntity<AdminApplicationResponse.Statistics> getStatistic() {
         return ResponseEntity.ok().body(applicationService.getStatistic());
+    }
+
+    @GetMapping("statistic/track")
+    @Operation(summary="직렬별 지원서류 개수 조회 API")
+    public ResponseEntity<Map<Track, Integer>> getTrackStatistic() {
+        return ResponseEntity.ok().body(applicationService.getTrackStatistic());
     }
 
 

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/admin/application/ApplicationTrackType.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/admin/application/ApplicationTrackType.java
@@ -1,8 +1,7 @@
 package com.gdsc_knu.official_homepage.dto.admin.application;
 
-import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 
 public interface ApplicationTrackType {
-    Track getTrack();
+    String getTrack();
     Integer getCount();
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/ApplicationRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/ApplicationRepository.java
@@ -27,10 +27,11 @@ public interface ApplicationRepository extends JpaRepository<Application, Long>,
     ApplicationStatisticType getStatistics();
 
 
-    @Query("SELECT a.track, COUNT(*) " +
+    @Query("SELECT a.track as track, COUNT(*) as count " +
             "FROM Application a " +
+            "WHERE a.applicationStatus != 'TEMPORAL' " +
             "GROUP BY a.track")
-    ApplicationTrackType getGroupByTrack();
+    List<ApplicationTrackType> getGroupByTrack();
 
     Page<Application> findByNameContaining(Pageable pageable, String name);
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminApplicationService.java
@@ -3,6 +3,7 @@ package com.gdsc_knu.official_homepage.service.admin;
 import com.gdsc_knu.official_homepage.dto.PagingResponse;
 import com.gdsc_knu.official_homepage.dto.admin.application.AdminApplicationResponse;
 import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationStatisticType;
+import com.gdsc_knu.official_homepage.dto.admin.application.ApplicationTrackType;
 import com.gdsc_knu.official_homepage.entity.application.Application;
 import com.gdsc_knu.official_homepage.entity.enumeration.ApplicationStatus;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
@@ -14,7 +15,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -32,6 +37,20 @@ public class AdminApplicationService {
                 statistic.getTotal() - statistic.getOpenCount(),
                 statistic.getApprovedCount(),
                 statistic.getRejectedCount());
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Track, Integer> getTrackStatistic() {
+        List<ApplicationTrackType> trackStatistics = applicationRepository.getGroupByTrack();
+        return Arrays.stream(Track.values())
+                .collect(Collectors.toMap(track -> track, track -> getTrackCount(trackStatistics, track)));
+    }
+
+    private Integer getTrackCount(List<ApplicationTrackType> trackStatistics, Track track) {
+        return trackStatistics.stream()
+                .filter(data -> data.getTrack().equals(track.name()))
+                .map(ApplicationTrackType::getCount)
+                .findFirst().orElse(0);
     }
 
 


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- 엑세스 토큰 유효시간 1일로 복구
- 직렬별로 최종제출된 지원서 개수 카운트 기능 구현

---

### ✨ 참고 사항
- map<직렬, 개수>의 형태로 응답을 구성하여 dto클래스를 따로 두지 않음.
---

### ⏰ 현재 버그

---

### ✏ Git Close
closes #84 