### PR TITLE
일반 사용자의 팀원 정보 조회 (#97)

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/controller/TeamController.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/controller/TeamController.java
@@ -1,0 +1,26 @@
+package com.gdsc_knu.official_homepage.controller;
+
+import com.gdsc_knu.official_homepage.dto.team.TeamResponse;
+import com.gdsc_knu.official_homepage.service.TeamService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "Team", description = "팀 관련 API")
+@RestController
+@RequestMapping("api/team")
+@RequiredArgsConstructor
+public class TeamController {
+    private final TeamService teamService;
+
+    @GetMapping("/{teamId}/member")
+    @Operation(summary = "팀원 정보 조회 API",
+            description = "해당 팀의 팀원목록(유저 ID, 이름, 직렬)을 반환합니다. (미배치된 팀은 조회되지 않습니다.)")
+    public ResponseEntity<List<TeamResponse.MemberInfo>> getTeamMembers(@PathVariable("teamId") Long teamId) {
+        return ResponseEntity.ok().body(teamService.getTeamMember(teamId));
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/team/TeamResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/team/TeamResponse.java
@@ -1,0 +1,27 @@
+package com.gdsc_knu.official_homepage.dto.team;
+
+import com.gdsc_knu.official_homepage.entity.Member;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TeamResponse {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberInfo {
+        private Long id;
+        private String name;
+        private String track;
+
+        public static MemberInfo from(Member member) {
+            return MemberInfo.builder()
+                    .id(member.getId())
+                    .name(member.getName())
+                    .track(member.getTrack().name())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/gdsc_knu/official_homepage/dto/team/TeamResponse.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/dto/team/TeamResponse.java
@@ -20,7 +20,9 @@ public class TeamResponse {
             return MemberInfo.builder()
                     .id(member.getId())
                     .name(member.getName())
-                    .track(member.getTrack().name())
+                    .track(member.getTrack() != null
+                            ? member.getTrack().name()
+                            : "undefined")
                     .build();
         }
     }

--- a/src/main/java/com/gdsc_knu/official_homepage/repository/MemberTeamRepository.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/repository/MemberTeamRepository.java
@@ -19,4 +19,10 @@ public interface MemberTeamRepository extends JpaRepository<MemberTeam, Long> {
     List<AdminTeamResponse.TeamMember> findAllByTeamId(@Param("teamId") Long teamId);
 
     List<MemberTeam> findAllMemberTeamByTeamId(Long teamId);
+
+    @Query("SELECT mt " +
+            "FROM MemberTeam mt " +
+            "JOIN FETCH mt.member " +
+            "WHERE mt.team.id = :teamId")
+    List<MemberTeam> findMembersByTeamId(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/gdsc_knu/official_homepage/service/TeamService.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/TeamService.java
@@ -1,0 +1,33 @@
+package com.gdsc_knu.official_homepage.service;
+
+import com.gdsc_knu.official_homepage.dto.team.TeamResponse;
+import com.gdsc_knu.official_homepage.entity.MemberTeam;
+import com.gdsc_knu.official_homepage.entity.Team;
+import com.gdsc_knu.official_homepage.exception.CustomException;
+import com.gdsc_knu.official_homepage.exception.ErrorCode;
+import com.gdsc_knu.official_homepage.repository.MemberTeamRepository;
+import com.gdsc_knu.official_homepage.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class TeamService {
+    private final MemberTeamRepository memberTeamRepository;
+    private final TeamRepository teamRepository;
+
+    public List<TeamResponse.MemberInfo> getTeamMember(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 팀입니다."));
+        if (team.getParent() == null)
+            throw new CustomException(ErrorCode.INVALID_INPUT, "정상 배정된 팀이 아닙니다.");
+
+        List<MemberTeam> memberTeams = memberTeamRepository.findMembersByTeamId(teamId);
+        return memberTeams.stream()
+                .map(memberTeam -> TeamResponse.MemberInfo.from(memberTeam.getMember()))
+                .toList();
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 일반 사용자의 팀원 정보 조회 기능 구현

## To Reviewers 📢
- 어드민 API의 팀원 조회는 부모팀으로 조회 미배치된 사용자를 모두 반환하기에 기존 코드 재활용하지 않고 새로운 메소드 작성
  - 추후 공통 부분은 하나의 메소드로 합치는 방법도 생각해 보겠습니다.
- member team repository에서 teamId로 가져올때 member를 조인해서 가져오는 jpql 코드가 2개로 중복되는데, projection dto 를 따로 정의하여 `findAllByTeamId` `findMembersByTeamId` 두 함수를 하나로 쓸 수 있도록 수정하면 좋을 것 같습니다.

## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- #97 