### PR TITLE
[Fix] 팀 배치 오류 관련 수정

### DIFF
--- a/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/MemberInfoServiceImpl.java
@@ -28,6 +28,7 @@ public class MemberInfoServiceImpl implements MemberInfoService {
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 
         List<TeamInfoResponse> teamInfos = member.getMemberTeams().stream()
+                .filter(memberTeam -> memberTeam.getTeam().getParent() != null)
                 .map(memberTeam -> new TeamInfoResponse(memberTeam.getTeam()))
                 .collect(Collectors.toList());
 

--- a/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
+++ b/src/main/java/com/gdsc_knu/official_homepage/service/admin/AdminTeamServiceImpl.java
@@ -5,6 +5,7 @@ import com.gdsc_knu.official_homepage.dto.member.TeamInfoResponse;
 import com.gdsc_knu.official_homepage.entity.Member;
 import com.gdsc_knu.official_homepage.entity.MemberTeam;
 import com.gdsc_knu.official_homepage.entity.Team;
+import com.gdsc_knu.official_homepage.entity.enumeration.Role;
 import com.gdsc_knu.official_homepage.entity.enumeration.Track;
 import com.gdsc_knu.official_homepage.exception.CustomException;
 import com.gdsc_knu.official_homepage.exception.ErrorCode;
@@ -46,7 +47,7 @@ public class AdminTeamServiceImpl implements AdminTeamService {
     }
 
     /**
-     * 새로운 부모 팀을 생성함. 직렬을 지정 하면 해당 직렬의 회원만 해당 팀에 소속
+     * 새로운 부모 팀을 생성함. 직렬을 지정 하면 해당 직렬의 회원(MEMBER,CORE)만 해당 팀에 소속
      * @param createRequest 새로운 부모 팀 생성 요청 (팀 이름, 트랙)
      * @return Long 새로 생성된 팀의 id
      */
@@ -64,6 +65,8 @@ public class AdminTeamServiceImpl implements AdminTeamService {
         List<Member> members = (track != null)
                 ? memberRepository.findAllByTrack(track)
                 : memberRepository.findAll();
+        members.removeIf(member -> member.getRole().equals(Role.ROLE_GUEST) || member.getRole().equals(Role.ROLE_TEMP));
+
         List<MemberTeam> memberTeams = members.stream()
                 .map(member -> MemberTeam.builder()
                         .member(member)


### PR DESCRIPTION
## 🔎 작업 내용
마이페이지 부모 팀 노출, 어드민페이지 팀 배치 시 정식 멤버가 아닌 회원 반환 오류를 수정했습니다.

## To Reviewers 📢


## 체크 리스트
- [ ] 테스트를 작성했습니다.
- [ ] 테스트를 통과했습니다.
- [ ] API 변경사항이 존재합니다.
- [ ] API 호출을 직접 실시하였고, 해당 데이터가 정상적으로 표시됩니다.
- [ ] 기존 코드에 영향을 주는 작업 내용이 존재합니다.
- [ ] 향후 추가적인 작업이 필요한 부분이 있습니다.

## ➕ 관련 이슈
- close #99 